### PR TITLE
dmaengine: dw-axi-dmac: Add support for Xuantie TH1520 DMA

### DIFF
--- a/arch/riscv/boot/dts/thead/th1520.dtsi
+++ b/arch/riscv/boot/dts/thead/th1520.dtsi
@@ -935,7 +935,7 @@
 		};
 
 		dmac0: dma-controller@ffefc00000 {
-			compatible = "snps,axi-dma-1.01a";
+			compatible = "xuantie,th1520-axi-dma";
 			reg = <0xff 0xefc00000 0x0 0x1000>;
 			interrupts = <27 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clk CLKGEN_DMAC_CPUSYS_ACLK>, <&clk CLKGEN_DMAC_CPUSYS_HCLK>;
@@ -967,7 +967,7 @@
 		};
 
 		dmac2: dma-controller@ffc8000000 {
-			compatible = "snps,axi-dma-1.01a";
+			compatible = "xuantie,th1520-axi-dma";
 			reg = <0xff 0xc8000000 0x0 0x2000>;
 			interrupts = <167 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&clk CLKGEN_DMAC_CPUSYS_ACLK>, <&clk CLKGEN_DMAC_CPUSYS_HCLK>;

--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -1649,6 +1649,9 @@ static const struct of_device_id dw_dma_of_id_table[] = {
 	}, {
 		.compatible = "starfive,jh7110-axi-dma",
 		.data = (void *)(AXI_DMA_FLAG_HAS_RESETS | AXI_DMA_FLAG_USE_CFG2),
+	}, {
+		.compatible = "xuantie,th1520-axi-dma",
+		.data = (void *)(AXI_DMA_FLAG_USE_CFG2),
 	},
 	{}
 };


### PR DESCRIPTION
add th1520 dma compatible with match data AXI_DMA_FLAG_USE_CFG2