### PR TITLE
audio: th1520: fixup compile warning of i2s driver

### DIFF
--- a/sound/soc/xuantie/th1520-i2s-8ch.c
+++ b/sound/soc/xuantie/th1520-i2s-8ch.c
@@ -585,8 +585,6 @@ static int th1520_audio_i2s_8ch_probe(struct platform_device *pdev)
 
 	int ret;
 	unsigned int irq;
-	const char *sprop;
-	const uint32_t *iprop;
 	struct resource *res;
 	struct th1520_i2s_priv *priv;
 	struct device *dev = &pdev->dev;

--- a/sound/soc/xuantie/th1520-i2s.c
+++ b/sound/soc/xuantie/th1520-i2s.c
@@ -679,8 +679,6 @@ static int th1520_audio_i2s_probe(struct platform_device *pdev)
 {
 	int ret;
 	unsigned int irq;
-	const char *sprop;
-	const uint32_t *iprop;
 	struct resource *res;
 	struct th1520_i2s_priv *i2s_priv;
 	struct device *dev = &pdev->dev;


### PR DESCRIPTION
fixup compile warnings
1. th1520-i2s.c:683:25: warning: unused variable 'iprop' [-Wunused-variable]
2. th1520-i2s.c:682:21: warning: unused variable 'sprop' [-Wunused-variable]