### PR TITLE
drm: Fix HDMI hot-plug problem

### DIFF
--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
@@ -2158,6 +2158,11 @@ static void hdmi_av_composer(struct dw_hdmi *hdmi,
 				    HDMI_MC_SWRSTZ);
 			drm_scdc_set_scrambling(hdmi->curr_conn, 0);
 		}
+	} else {
+		hdmi_writeb(hdmi, 0, HDMI_FC_SCRAMBLER_CTRL);
+		hdmi_writeb(hdmi, (u8)~HDMI_MC_SWRSTZ_TMDSSWRST_REQ,
+			    HDMI_MC_SWRSTZ);
+		drm_scdc_set_scrambling(hdmi->curr_conn, 0);
 	}
 
 	/* Set up horizontal active pixel width */


### PR DESCRIPTION
Fix HDMI hot-plug problem which occur at the time of switching from 4K@60 t0 1080p@60 monitor.