### PR TITLE
ci: fix aon error (use old opensbi fw)

### DIFF
--- a/.github/workflows/th1520.yml
+++ b/.github/workflows/th1520.yml
@@ -141,6 +141,9 @@ jobs:
             sudo chroot mnt sh -c 'apt update && apt dist-upgrade -y'
             # Add preinstalled software
             sudo chroot mnt sh -c 'apt install -y cpufrequtils python3-ruamel.yaml iperf firmware-realtek'
+            # Install old version of OpenSBI to solve devicetree aon error (th1520-mainline-opensbi)
+            sudo chroot mnt sh -c 'apt install --allow-downgrades -y th1520-boot-firmware=2024.05.10+sdk1.5.4'
+            sudo chroot mnt sh -c 'apt-mark hold th1520-boot-firmware'
             sudo umount -l mnt
             zstd boot-lpi4amain-ci-${TIMESTAMP}.ext4
             zstd root-lpi4amain-ci-${TIMESTAMP}.ext4


### PR DESCRIPTION
Fix booting error `Failed to get 'opensbi-mboxes' property: -1`

error log here:
```
[APP][E] protocol_connect failed, exit.
-----------------------------------------
  _____             _  _____ _____  _  __
 |  __ \           (_)/ ____|  __ \| |/ /
 | |__) |   _ _   _ _| (___ | |  | | ' /
 |  _  / | | | | | | |\___ \| |  | |  <
 | | \ \ |_| | |_| | |____) | |__| | . \
 |_|  \_\__,_|\__, |_|_____/|_____/|_|\_\
               __/ |
              |___/
                    -- Presented by ISCAS
-----------------------------------------

U-Boot SPL 2020.01-g96627087 (May 29 2024 - 08:35:16 +0000)
FM[1] lpddr4x dualrank freq=3733 64bit dbi_off=n sdram init
found ddr boundary <0x200000000>
ddr initialized, jump to uboot
image has no header


U-Boot 2020.01-g96627087 (May 29 2024 - 08:35:16 +0000)

CPU:   rv64imafdcvsu
Model: T-HEAD c910 light
DRAM:  8 GiB
aon wakeup by gpio enabled
aon wakeup by rtc enabled
iic id:0 addr_mode:0 speed:2
C910 CPU FREQ: 750MHz
MMC:   sdhci@ffe7080000: 0, sd@ffe7090000: 1
Loading Environment from MMC... OK
splash screen startup cost 72 ms
In:    serial
Out:   serial
Err:   serial
light_c910_set_gpio_output_high: trying to set gpio output high
light_c910_set_gpio_output_high: no /config node?
ethaddr: fe:25:cc:95:07:96
eth1addr: fe:25:cc:95:07:97
Net:   ethernet@ffe7070000 (eth0) using MAC address - fe:25:cc:95:07:96
eth0: ethernet@ffe7070000ethernet@ffe7070000:0 is connected to ethernet@ffe7070000.  Reconnecting to ethernet@ffe7060000
ethernet@ffe7060000 (eth1) using MAC address - fe:25:cc:95:07:97
, eth1: ethernet@ffe7060000
Hit any key to stop autoboot:  0
Card did not respond to voltage select!
53192 bytes read in 1 ms (50.7 MiB/s)
pmic_dev_num:2 offset:60 addr:1099510546492
regu_num:17 offset:178 addr:1099510546610
-->pmic_dev_num:2 offset:60
-->regu_num:17 offset:178
5281216 bytes read in 19 ms (265.1 MiB/s)
1736 bytes read in 1 ms (1.7 MiB/s)
271256 bytes read in 5 ms (51.7 MiB/s)
 not find hibernate sign
Retrieving file: /extlinux/extlinux.conf
921 bytes read in 1 ms (899.4 KiB/s)
U-Boot menu
1:      RevyOS GNU/Linux 6.6.36-g1c629e6fe983
2:      RevyOS GNU/Linux 6.6.36-g1c629e6fe983 (rescue target)
Enter choice: 1
1:      RevyOS GNU/Linux 6.6.36-g1c629e6fe983
Retrieving file: /initrd.img-6.6.36-g1c629e6fe983
5945338 bytes read in 22 ms (257.7 MiB/s)
Retrieving file: /vmlinux-6.6.36-g1c629e6fe983
17094144 bytes read in 59 ms (276.3 MiB/s)
append: root=/dev/mmcblk0p4 console=ttyS0,115200 rootwait rw earlycon clk_ignore_unused loglevel=7 eth= rootrwoptions=rw,noatime rootrwreset=yes
Retrieving file: /dtbs/linux-image-6.6.36-g1c629e6fe983/thead/th1520-lichee-pi-4a.dtb
46139 bytes read in 2 ms (22 MiB/s)
   Loading Ramdisk to 1fa54000, end 1ffff7fa ... OK
ERROR: reserving fdt memory region failed (addr=32e00000 size=600000)
ERROR: reserving fdt memory region failed (addr=33400000 size=200000)
ERROR: reserving fdt memory region failed (addr=33600000 size=200000)
   Using Device Tree in place at 0000000003800000, end 000000000380e43a

Starting kernel ...

## fdt has no reset_sample

OpenSBI v1.4
   ____                    _____ ____ _____
  / __ \                  / ____|  _ \_   _|
 | |  | |_ __   ___ _ __ | (___ | |_) || |
 | |  | | '_ \ / _ \ '_ \ \___ \|  _ < | |
 | |__| | |_) |  __/ | | |____) | |_) || |_
  \____/| .__/ \___|_| |_|_____/|____/_____|
        | |
        |_|

core:0 thead_generic_final_init: line:408 enter. cold_boot:1
fdt addr get 58720256
Failed to get 'opensbi-mboxes' property: -1
thead aon init faildinit_coldboot: platform final init failed (error -1)
```