### PR TITLE
riscv: makefile: Add xuantie_rv32 related targets

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -220,3 +220,11 @@ xuantie_defconfig:
 PHONY += xuantie_debug_defconfig
 xuantie_debug_defconfig:
 	$(Q)$(MAKE) -f $(srctree)/Makefile defconfig thp.config fs.config debug.config ftrace.config ebpf.config kdump.config sched.config
+
+PHONY += xuantie_rv32_defconfig
+xuantie_rv32_defconfig:
+	$(Q)$(MAKE) -f $(srctree)/Makefile defconfig 32-bit.config 12HZ.config fs.config
+
+PHONY += xuantie_rv32_debug_defconfig
+xuantie_rv32_debug_defconfig:
+	$(Q)$(MAKE) -f $(srctree)/Makefile defconfig 32-bit.config fs.config debug.config ftrace.config ebpf.config

--- a/arch/riscv/include/asm/pgtable.h
+++ b/arch/riscv/include/asm/pgtable.h
@@ -929,6 +929,7 @@ extern uintptr_t _dtb_early_pa;
 #endif /* CONFIG_XIP_KERNEL */
 extern u64 satp_mode;
 extern bool pgtable_l4_enabled;
+extern bool pgtable_l5_enabled;
 
 void paging_init(void);
 void misc_mem_init(void);


### PR DESCRIPTION
For xuantie processor testing.