### PR TITLE
riscv: Controls execution of check_unaligned_access

### DIFF
--- a/arch/riscv/kernel/cpufeature.c
+++ b/arch/riscv/kernel/cpufeature.c
@@ -576,6 +576,14 @@ unsigned long riscv_get_elf_hwcap(void)
 	return hwcap;
 }
 
+static bool param_check_unaligned_access = true;
+static int __init parse_check_unaligned_access(char *arg)
+{
+	param_check_unaligned_access = false;
+	return 0;
+}
+early_param("no_check_unaligned_access", parse_check_unaligned_access);
+
 void check_unaligned_access(int cpu)
 {
 	u64 start_cycles, end_cycles;
@@ -587,6 +595,9 @@ void check_unaligned_access(int cpu)
 	void *dst;
 	void *src;
 	long speed = RISCV_HWPROBE_MISALIGNED_SLOW;
+
+	if (!param_check_unaligned_access)
+		return;
 
 	/* We are already set since the last check */
 	if (per_cpu(misaligned_access_speed, cpu) != RISCV_HWPROBE_MISALIGNED_UNKNOWN)


### PR DESCRIPTION
When riscv boots, each core will execute check_unaligned_access, which is very time-consuming and unnecessary. In particular, the time consumption of multi-core startup increases greatly in the FPGA environment. By adding early_param no_check_unaligned_access, we can control whether to execute it by bootargs in DTS.