### PR TITLE
K230: ai2d: select DMA_SHARED_BUFFER

### DIFF
--- a/drivers/misc/canaan/ai2d/Kconfig
+++ b/drivers/misc/canaan/ai2d/Kconfig
@@ -1,6 +1,7 @@
 config K230_AI2D_DRIVER
 		tristate "K230 AI2D driver"
 		default	m
+		select DMA_SHARED_BUFFER
 		help
 		This option enables support for K230
 		Say Y for enabling the k230 ai2d driver


### PR DESCRIPTION
Related issue: <https://github.com/ruyisdk/linux-xuantie-kernel/issues/214>.