### PR TITLE
riscv: Fix toolchain vector detection

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -535,8 +535,8 @@ config RISCV_ISA_SVPBMT
 config TOOLCHAIN_HAS_V
 	bool
 	default y
-	depends on !64BIT || $(cc-option,-mabi=lp64 -march=rv64iv)
-	depends on !32BIT || $(cc-option,-mabi=ilp32 -march=rv32iv)
+	depends on !64BIT || $(cc-option,-mabi=lp64 -march=rv64imv)
+	depends on !32BIT || $(cc-option,-mabi=ilp32 -march=rv32imv)
 
 config RISCV_ISA_V
 	bool "VECTOR extension support"


### PR DESCRIPTION
A recent change to gcc flags rv64iv as no longer valid:

   cc1: sorry, unimplemented: Currently the 'V' implementation
   requires the 'M' extension

and as a result vector support is disabled. Fix this by adding m to our toolchain vector detection code.


Fixes: fa8e7cce55da ("riscv: Enable Vector code to be built")
Link: https://lore.kernel.org/r/20240819001131.1738806-1-antonb@tenstorrent.com

## Summary by Sourcery

Bug Fixes:
- Fix RISC-V vector support being disabled by accounting for GCC's requirement that the V extension be used together with the M extension in toolchain detection.