### PR TITLE
RISC-V: KVM: Change the SBI specification version to v2.0

### DIFF
--- a/arch/riscv/include/asm/kvm_vcpu_sbi.h
+++ b/arch/riscv/include/asm/kvm_vcpu_sbi.h
@@ -11,7 +11,7 @@
 
 #define KVM_SBI_IMPID 3
 
-#define KVM_SBI_VERSION_MAJOR 1
+#define KVM_SBI_VERSION_MAJOR 2
 #define KVM_SBI_VERSION_MINOR 0
 
 enum kvm_riscv_sbi_ext_status {


### PR DESCRIPTION
We will be implementing SBI DBCN extension for KVM RISC-V so let us change the KVM RISC-V SBI specification version to v2.0.


Reviewed-by: Andrew Jones <ajones@ventanamicro.com>


Change-Id: I12cb5c3f616331eba8314c02287895808d42be3b

## Summary by Sourcery

Enhancements:
- Align KVM RISC-V SBI version macros with the SBI v2.0 specification.