### PR TITLE
selftests/harness: Increase TEST_TIMEOUT_DEFAULT

### DIFF
--- a/tools/testing/selftests/kselftest_harness.h
+++ b/tools/testing/selftests/kselftest_harness.h
@@ -69,7 +69,7 @@
 
 #include "kselftest.h"
 
-#define TEST_TIMEOUT_DEFAULT 30
+#define TEST_TIMEOUT_DEFAULT 60
 
 /* Utilities exposed to the test definitions */
 #ifndef TH_LOG_STREAM


### PR DESCRIPTION
In some multi-FPGA cascaded environments, the CPU frequency is low (only 10MHz), and some kselftest cases (fs/epoll61, etc.) fail to execute due to timeouts. Therefore, increasing the timeout period can help avoid this.

## Summary by Sourcery

Enhancements:
- Extend the kselftest harness default test timeout from 30 to 60 seconds to better accommodate slow environments.