### PR TITLE
ci: bump xt64_toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1755679709552
-  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0-20250627.tar.gz
+  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1770908769007
+  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0-20260204.tar.gz
   rv32_toolchain: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2026.01.23
   rv32_toolchain_file_name: riscv32-glibc-ubuntu-22.04-gcc.tar.xz
   rv64_toolchain: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2026.01.23

--- a/.github/workflows/k230.yml
+++ b/.github/workflows/k230.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 3 * * *"
 
 env:
-  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1755679709552
-  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0-20250627.tar.gz
+  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1770908769007
+  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0-20260204.tar.gz
   rv64_toolchain: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2026.01.23
   rv64_toolchain_file_name: riscv64-glibc-ubuntu-22.04-gcc.tar.xz
   rv64ilp32_toolchain: https://github.com/ruyisdk/riscv-gnu-toolchain-rv64ilp32/releases/download/2025.01.16
@@ -76,7 +76,7 @@ jobs:
                 export PATH="/opt/riscv/bin:$PATH"
               fi
               if [ x"${{ matrix.name }}" = x"linux-64lp64-xt" ]; then
-                export PATH="/opt/Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0/bin:$PATH"
+                export PATH="/opt/Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0/bin:$PATH"
               fi
               if [ x"${{ matrix.name }}" = x"linux-64ilp32" ]; then
                 export PATH="/opt/riscv/bin:$PATH"
@@ -130,7 +130,7 @@ jobs:
         run: ls -R $GITHUB_WORKSPACE
       - name: 'test kernel'
         run: |
-            export PATH="/opt/Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0/bin:$PATH"
+            export PATH="/opt/Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0/bin:$PATH"
             cd k230-linux-64ilp32
             init_cp2112.sh
             # reset board -> intercept uboot -> start debug server -> load kernel using gdb

--- a/.github/workflows/th1520.yml
+++ b/.github/workflows/th1520.yml
@@ -8,8 +8,8 @@ on:
     - cron: "0 3 * * *"
 
 env:
-  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1755679709552
-  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0-20250627.tar.gz
+  xt64_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1770908769007
+  xt64_toolchain_file_name: Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0-20260204.tar.gz
   rv64_toolchain: https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2026.01.23
   rv64_toolchain_file_name: riscv64-glibc-ubuntu-22.04-gcc.tar.xz
   ARCH: riscv
@@ -73,7 +73,7 @@ jobs:
                 export PATH="/opt/riscv/bin:$PATH"
               fi
               if [ x"${{ matrix.name }}" = x"linux-64lp64-xt" ]; then
-                export PATH="/opt/Xuantie-900-gcc-linux-6.6.0-glibc-x86_64-V3.2.0/bin:$PATH"
+                export PATH="/opt/Xuantie-900-gcc-linux-6.6.36-glibc-x86_64-V3.3.0/bin:$PATH"
               fi
               pushd kernel
                 make th1520_defconfig


### PR DESCRIPTION
Xuantie toolchains: v3.3.0

## Summary by Sourcery

Build:
- Point xt64 toolchain URL and filename in CI workflow configs to the Xuantie-900 V3.3.0 toolchain archive.