### PR TITLE
Linux 6.6.36 rv64ilp32 fixup

### DIFF
--- a/arch/riscv/include/asm/bitops.h
+++ b/arch/riscv/include/asm/bitops.h
@@ -25,14 +25,27 @@
 #include <asm/alternative-macros.h>
 #include <asm/hwcap.h>
 
-#if (BITS_PER_LONG == 64)
+#if (__riscv_xlen == 64)
 #define CTZW	"ctzw "
 #define CLZW	"clzw "
+
+#if (BITS_PER_LONG == 64)
+#define CTZ	"ctz "
+#define CLZ	"clz "
 #elif (BITS_PER_LONG == 32)
-#define CTZW	"ctz "
-#define CLZW	"clz "
+#define CTZ	"ctzw "
+#define CLZ	"clzw "
 #else
 #error "Unexpected BITS_PER_LONG"
+#endif
+
+#elif (__riscv_xlen == 32)
+#define CTZW	"ctz "
+#define CLZW	"clz "
+#define CTZ	"ctz "
+#define CLZ	"clz "
+#else
+#error "Unexpected __riscv_xlen"
 #endif
 
 static __always_inline unsigned long variable__ffs(unsigned long word)
@@ -45,7 +58,7 @@ static __always_inline unsigned long variable__ffs(unsigned long word)
 
 	asm volatile (".option push\n"
 		      ".option arch,+zbb\n"
-		      "ctz %0, %1\n"
+		      CTZ "%0, %1\n"
 		      ".option pop\n"
 		      : "=r" (word) : "r" (word) :);
 
@@ -101,7 +114,7 @@ static __always_inline unsigned long variable__fls(unsigned long word)
 
 	asm volatile (".option push\n"
 		      ".option arch,+zbb\n"
-		      "clz %0, %1\n"
+		      CLZ "%0, %1\n"
 		      ".option pop\n"
 		      : "=r" (word) : "r" (word) :);
 

--- a/arch/riscv/kernel/entry.S
+++ b/arch/riscv/kernel/entry.S
@@ -119,7 +119,7 @@ _save_context:
 	add t0, t1, t0
 	/* Check if exception code lies within bounds */
 	bgeu t0, t2, 3f
-	REG_L t1, 0(t0)
+	PTR_L t1, 0(t0)
 2:
 	jalr t1
 	j ret_from_exception


### PR DESCRIPTION
Fixup rv64ilp32 boot problem

## Summary by Sourcery

Fix RISC-V rv64ilp32 boot issues by correcting bit operation instruction selection and using pointer-sized loads in the exception handler.

Bug Fixes:
- Ensure the correct count-leading/trailing-zero instructions are selected based on both XLEN and BITS_PER_LONG, including rv64ilp32 configurations.
- Use pointer-sized loads for exception vector entries to avoid faults in mixed XLEN/ABI RISC-V configurations.