### PR TITLE
riscv: signal: fix the size of signal frame

### DIFF
--- a/arch/riscv/kernel/setup.c
+++ b/arch/riscv/kernel/setup.c
@@ -342,8 +342,8 @@ void __init setup_arch(char **cmdline_p)
 
 	riscv_init_cbo_blocksizes();
 	riscv_fill_hwcap();
-	init_rt_signal_env();
 	apply_boot_alternatives();
+	init_rt_signal_env();
 
 	if (IS_ENABLED(CONFIG_RISCV_ISA_ZICBOM) &&
 	    riscv_isa_extension_available(NULL, ZICBOM))

--- a/arch/riscv/kernel/signal.c
+++ b/arch/riscv/kernel/signal.c
@@ -212,12 +212,6 @@ static size_t get_rt_frame_size(bool cal_all)
 		if (cal_all || riscv_v_vstate_query(task_pt_regs(current)))
 			total_context_size += riscv_v_sc_size;
 	}
-	/*
-	 * Preserved a __riscv_ctx_hdr for END signal context header if an
-	 * extension uses __riscv_extra_ext_header
-	 */
-	if (total_context_size)
-		total_context_size += sizeof(struct __riscv_ctx_hdr);
 
 	frame_size += total_context_size;
 


### PR DESCRIPTION
This series addresses two issues about the RISC-V signal frame size calculation. PATCH1 removes the unnecessary header preservation for the END header. PATCH2 reorders the apply_boot_alternatives() and init_rt_signal_env() to get the correct signal_minsigstksz.

## Summary by Sourcery

Adjust RISC-V signal frame sizing logic and initialization order to ensure correct minimum signal stack size is computed.

Bug Fixes:
- Fix overestimation of the RISC-V signal frame size by removing an unnecessary reserved header for the END signal context.
- Fix incorrect computation of signal_minsigstksz by initializing the real-time signal environment after applying boot-time alternatives.