### PR TITLE
drivers: gpu: drm: canaan: Fixup menuconfig

### DIFF
--- a/arch/riscv/Kconfig.socs
+++ b/arch/riscv/Kconfig.socs
@@ -75,6 +75,7 @@ config SOC_VIRT
 
 config ARCH_CANAAN
 	bool "Canaan Kendryte SoC"
+	select DRM if RISCV
 	help
 	  This enables support for Canaan Kendryte series SoC platform hardware.
 


### PR DESCRIPTION
Fixup menuconfig error:

drivers/gpu/drm/Kconfig:8:error: recursive dependency detected!
drivers/gpu/drm/Kconfig:8:      symbol DRM is selected by DRM_CANAAN
drivers/gpu/drm/canaan/Kconfig:2:       symbol DRM_CANAAN depends on OF
drivers/of/Kconfig:5:   symbol OF is selected by X86_INTEL_CE
arch/x86/Kconfig:598:   symbol X86_INTEL_CE depends on X86_IO_APIC
arch/x86/Kconfig:1113:  symbol X86_IO_APIC depends on X86_LOCAL_APIC
arch/x86/Kconfig:1108:  symbol X86_LOCAL_APIC depends on X86_UP_APIC
arch/x86/Kconfig:1083:  symbol X86_UP_APIC prompt is visible depending on PCI_MSI
drivers/pci/Kconfig:39: symbol PCI_MSI is selected by AMD_IOMMU
drivers/iommu/amd/Kconfig:3:    symbol AMD_IOMMU depends on IOMMU_SUPPORT
drivers/iommu/Kconfig:14:       symbol IOMMU_SUPPORT is selected by DRM_PANFROST
drivers/gpu/drm/panfrost/Kconfig:3:     symbol DRM_PANFROST depends on DRM
For a resolution refer to Documentation/kbuild/kconfig-language.rst
subsection "Kconfig recursive dependency limitations"

## Summary by Sourcery

Bug Fixes:
- Fix a Kconfig recursion error triggered by DRM_CANAAN and DRM-related dependencies in menuconfig.