### PR TITLE
riscv: mm: Fixup no5lvl fails on 128TB physical address

### DIFF
--- a/arch/riscv/mm/init.c
+++ b/arch/riscv/mm/init.c
@@ -785,6 +785,27 @@ static int __init print_no5lvl(char *p)
 }
 early_param("no5lvl", print_no5lvl);
 
+static bool __init is_vaddr_valid(unsigned long va)
+{
+	unsigned long up = 0;
+
+	switch (satp_mode) {
+	case SATP_MODE_39:
+		up = 1UL << 38;
+		break;
+	case SATP_MODE_48:
+		up = 1UL << 47;
+		break;
+	case SATP_MODE_57:
+		up = 1UL << 56;
+		break;
+	default:
+		return false;
+	}
+
+	return (va < up) || (va >= (ULONG_MAX - up + 1));
+}
+
 /*
  * There is a simple way to determine if 4-level is supported by the
  * underlying hardware: establish 1:1 mapping in 4-level page table mode
@@ -826,6 +847,9 @@ static __init void set_satp_mode(uintptr_t dtb_pa)
 			   set_satp_mode_pmd + PMD_SIZE,
 			   PMD_SIZE, PAGE_KERNEL_EXEC);
 retry:
+	if (!is_vaddr_valid(set_satp_mode_pmd))
+		goto out;
+
 	create_pgd_mapping(early_pg_dir,
 			   set_satp_mode_pmd,
 			   pgtable_l5_enabled ?
@@ -848,6 +872,7 @@ retry:
 		disable_pgtable_l4();
 	}
 
+out:
 	memset(early_pg_dir, 0, PAGE_SIZE);
 	memset(early_p4d, 0, PAGE_SIZE);
 	memset(early_pud, 0, PAGE_SIZE);


### PR DESCRIPTION
Unlike no4lvl, no5lvl still continues detect satp, which requires va=pa mapping. When pa=0x800000000000, no5lvl would fail in Sv48 mode due to an illegal VA value of 0x800000000000.

So, prevent detecting the satp flow for no5lvl, which is the same as no4lvl. That means the user needs to know the machine's exact mode when using no5lvl.


Change-Id: I14ad2507c03558ac600fdea665bdf0e14f6d59f5

## Summary by Sourcery

Bug Fixes:
- Avoid illegal virtual address usage in Sv48 mode when running with 128TB physical addresses and no5lvl configuration by stopping the satp detection flow after disabling L5 page tables.