### PR TITLE
bits: guard __riscv_xlen with defined(__riscv) for non-RISC-V builds

### DIFF
--- a/include/linux/bits.h
+++ b/include/linux/bits.h
@@ -31,10 +31,12 @@
 #endif
 
 #ifndef xlen_t
-#if __riscv_xlen == 64
+#if defined(__riscv) && (__riscv_xlen == 64)
 #define xlen_t u64
-#else
+#elif defined(__riscv)
 #define xlen_t u32
+#else
+#define xlen_t unsigned long
 #endif
 #endif
 


### PR DESCRIPTION
The xuantie kernel tree's xlen_t hack in include/linux/bits.h tests __riscv_xlen unconditionally:

    #if __riscv_xlen == 64

The C preprocessor evaluates undefined identifiers in #if expressions as 0; with CONFIG_WERROR=y (default on x86_64_defconfig and other arches) this trips -Werror=undef and aborts the build at the very first compilation unit, kernel/bounds.s, when cross-compiling for non-RISC-V architectures:

    include/linux/bits.h:34:5: error: "__riscv_xlen" is not defined,
        evaluates to 0 [-Werror=undef]

Guard the test with defined(__riscv) and add an unsigned-long fallback for non-RISC-V, which matches BITS_PER_LONG and preserves the original upstream __GENMASK semantics on those targets.

Verified by building x86_64 defconfig (CONFIG_WERROR=y): kernel/bounds.s and representative GENMASK-heavy objects (init/main.o, mm/page_alloc.o, kernel/sched/core.o, drivers/tty/serial/8250/8250_core.o) all build clean.

## Summary by Sourcery

Bug Fixes:
- Fix build failures on non-RISC-V architectures by avoiding unconditional use of the __riscv_xlen macro in preprocessor conditions.