### PR TITLE
riscv: configs: drop ftrace and ebpf fragments from rv32 debug defconfig

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -250,4 +250,4 @@ xuantie_rv32_defconfig:
 
 PHONY += xuantie_rv32_debug_defconfig
 xuantie_rv32_debug_defconfig:
-	$(Q)$(MAKE) -f $(srctree)/Makefile defconfig 32-bit.config fs.config tee.config debuginfo.config xt_test.config ftrace.config ebpf.config
+	$(Q)$(MAKE) -f $(srctree)/Makefile defconfig 32-bit.config fs.config tee.config debuginfo.config xt_test.config


### PR DESCRIPTION
Remove ftrace.config and ebpf.config from xuantie_rv32_debug_defconfig.

RV32 ftrace and eBPF kernel support is immature: BPF JIT for RV32 has limited instruction coverage, BTF depends on DEBUG_INFO=y which triggers a known upstream RV32 toolchain bug (linker relaxation + 32-bit r_info overflow causes .export_symbol relocations to point at DWARF local labels instead of exported globals, failing modpost with "local symbol was exported"), and the userspace ecosystem (libbpf, bpftool, bcc) has near-zero RV32 testing. The upstream bug is acknowledged by RISC-V maintainers but has no fix yet.

Link: https://lore.kernel.org/linux-riscv/960240908.630790.1748641210849@privateemail.com/
Link: https://lore.kernel.org/linux-riscv/d5e49344-e0c2-4095-bd1f-d2d23a8e6534@ghiti.fr/

## Summary by Sourcery

Build:
- Remove ftrace.config and ebpf.config from the xuantie_rv32_debug_defconfig make target to simplify the 32-bit debug configuration.