### PR TITLE
Fix build on arm64

### DIFF
--- a/drivers/firmware/xuantie/Makefile
+++ b/drivers/firmware/xuantie/Makefile
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0
 obj-$(CONFIG_TH1520_AON)	+= th1520_aon.o 
 obj-$(CONFIG_TH1520_AON_PD)	+= th1520_aon_pd.o
-obj-y += th1520_proc_debug.o
+obj-$(CONFIG_TH1520_AON) += th1520_proc_debug.o

--- a/drivers/media/platform/canaan/vpu/Kconfig
+++ b/drivers/media/platform/canaan/vpu/Kconfig
@@ -1,5 +1,6 @@
 config VPU_CANAAN
 	tristate "Linlon VPU support."
+	depends on RISCV
 	depends on VIDEO_DEV
 	depends on COMMON_CLK && HAS_DMA
 	select VIDEO_V4L2_SUBDEV_API

--- a/drivers/misc/canaan/ai2d/Kconfig
+++ b/drivers/misc/canaan/ai2d/Kconfig
@@ -1,5 +1,6 @@
 config K230_AI2D_DRIVER
 		tristate "K230 AI2D driver"
+		depends on RISCV
 		default	m
 		select DMA_SHARED_BUFFER
 		help

--- a/drivers/misc/canaan/gnne/Kconfig
+++ b/drivers/misc/canaan/gnne/Kconfig
@@ -1,5 +1,6 @@
 config K230_GNNE_DRIVER
 		tristate "K230 GNNE driver"
+		depends on RISCV
 		default m
 		help
 		This option enables support for K230

--- a/drivers/misc/canaan/mmz/Kconfig
+++ b/drivers/misc/canaan/mmz/Kconfig
@@ -1,5 +1,6 @@
 config K230_MMZ
 	tristate "K230 mem zone driver"
+	depends on RISCV
 	default	m
 	help
 		This option enables support for K230

--- a/drivers/usb/dwc3/Makefile
+++ b/drivers/usb/dwc3/Makefile
@@ -55,5 +55,4 @@ obj-$(CONFIG_USB_DWC3_QCOM)		+= dwc3-qcom.o
 obj-$(CONFIG_USB_DWC3_IMX8MP)		+= dwc3-imx8mp.o
 obj-$(CONFIG_USB_DWC3_XILINX)		+= dwc3-xilinx.o
 obj-$(CONFIG_USB_DWC3_OCTEON)		+= dwc3-octeon.o
-obj-$(CONFIG_USB_DWC3_RTK)		+= dwc3-rtk.o
 obj-$(CONFIG_USB_DWC3_XUANTIE)		+= dwc3-xuantie.o

--- a/include/linux/bits.h
+++ b/include/linux/bits.h
@@ -35,14 +35,24 @@
 #define xlen_t u64
 #elif defined(__riscv)
 #define xlen_t u32
-#else
-#define xlen_t unsigned long
 #endif
 #endif
 
+/*
+ * xlen_t-based __GENMASK is only used in RISC-V C code (to keep s64ilp32
+ * working where unsigned long is narrower than the XLEN register width).
+ * Assembly and non-RISC-V targets fall back to the upstream form, which uses
+ * UL()/BITS_PER_LONG and contains no C-style casts that GNU as cannot parse.
+ */
+#if !defined(__ASSEMBLY__) && defined(__riscv)
 #define __GENMASK(h, l) \
-	(ulong)(((~(xlen_t)(0)) - ((xlen_t)(1) << (l)) + 1) & \
+	(unsigned long)(((~(xlen_t)(0)) - ((xlen_t)(1) << (l)) + 1) & \
 	 (~(xlen_t)(0) >> (sizeof(xlen_t) * BITS_PER_BYTE - 1 - (h))))
+#else
+#define __GENMASK(h, l) \
+	(((~UL(0)) - (UL(1) << (l)) + 1) & \
+	 (~UL(0) >> (BITS_PER_LONG - 1 - (h))))
+#endif
 #define GENMASK(h, l) \
 	(GENMASK_INPUT_CHECK(h, l) + __GENMASK(h, l))
 


### PR DESCRIPTION
## Summary by Sourcery

Fix architecture-specific build issues and clean up configuration-dependent driver builds.

Bug Fixes:
- Correct __GENMASK implementation to only use xlen_t on RISC-V C code and fall back to the generic UL/BITS_PER_LONG form elsewhere to restore builds on non-RISC-V architectures.
- Make th1520_proc_debug driver build conditional on CONFIG_TH1520_AON instead of always building it.
- Stop building the unsupported or unused DWC3 Realtek (dwc3-rtk) driver to avoid related build problems.

Build:
- Adjust firmware and USB DWC3 Makefiles to align object builds with the intended Kconfig options and supported platforms.