### PR TITLE
perf vendor events riscv: Fix XUANTIE C950 JSON

### DIFF
--- a/tools/perf/pmu-events/arch/riscv/xuantie/c925/l2c.json
+++ b/tools/perf/pmu-events/arch/riscv/xuantie/c925/l2c.json
@@ -56,7 +56,7 @@
     },
     {
         "EventName": "bus.wr.access",
-        "EventCode": "0x000000af",
+        "EventCode": "0x000000ad",
         "BriefDescription": "bus evict/write access count."
     },
     {

--- a/tools/perf/pmu-events/arch/riscv/xuantie/c930/l2c.json
+++ b/tools/perf/pmu-events/arch/riscv/xuantie/c930/l2c.json
@@ -56,7 +56,7 @@
     },
     {
         "EventName": "bus.wr.access",
-        "EventCode": "0x000000af",
+        "EventCode": "0x000000ad",
         "BriefDescription": "bus evict/write access count."
     },
     {

--- a/tools/perf/pmu-events/arch/riscv/xuantie/c950/l2c.json
+++ b/tools/perf/pmu-events/arch/riscv/xuantie/c950/l2c.json
@@ -56,7 +56,7 @@
     },
     {
         "EventName": "bus.wr.access",
-        "EventCode": "0x000000af",
+        "EventCode": "0x000000ad",
         "BriefDescription": "bus evict/write access count."
     },
     {


### PR DESCRIPTION
## Summary by Sourcery

Correct Xuantie RISC-V L2 cache PMU event JSON descriptions for multiple cores.

Bug Fixes:
- Fix inconsistencies in Xuantie C950 L2C PMU event JSON definitions.
- Align Xuantie C925 and C930 L2C PMU event JSON data with the corrected format.