### PR TITLE
irqchip/riscv-imsic: Fix boot time update effective affinity warning

### DIFF
--- a/drivers/irqchip/irq-riscv-imsic-platform.c
+++ b/drivers/irqchip/irq-riscv-imsic-platform.c
@@ -170,6 +170,8 @@ static int imsic_irq_domain_alloc(struct irq_domain *domain,
 			    handle_simple_irq, NULL, NULL);
 	irq_set_noprobe(virq);
 	irq_set_affinity(virq, cpu_online_mask);
+	irq_data_update_effective_affinity(irq_get_irq_data(virq),
+					   cpumask_of(vec->cpu));
 
 	/*
 	 * IMSIC does not implement irq_disable() so Linux interrupt


### PR DESCRIPTION
Currently, the following warning is observed on the QEMU virt machine: genirq: irq_chip APLIC-MSI-d00000000.aplic did not update eff. affinity mask of irq 12

The above warning is because the IMSIC driver does not set the initial value of effective affinity in the interrupt descriptor. To address this, initialize the effective affinity in imsic_irq_domain_alloc().

Link: https://lore.kernel.org/r/20240413065210.315896-1-apatel@ventanamicro.com

## Summary by Sourcery

Bug Fixes:
- Set the initial effective affinity mask for IMSIC IRQs to prevent genirq warnings about non-updated effective affinity during boot.