### PR TITLE
perf env: Normalize riscv architecture names

### DIFF
--- a/tools/perf/util/env.c
+++ b/tools/perf/util/env.c
@@ -448,6 +448,8 @@ static const char *normalize_arch(char *arch)
 		return "sh";
 	if (!strncmp(arch, "loongarch", 9))
 		return "loongarch";
+	if (!strncmp(arch, "riscv", 5))
+		return "riscv";
 
 	return arch;
 }


### PR DESCRIPTION
Backport for linux-6.6.y: normalize_arch() lacks a riscv rule, so on RISC-V systems uname() reports "riscv64" while the perf register lookup helpers only know "riscv". DWARF callchain post-unwinding then fails with "Fail to find SP register for arch riscv64" and perf script/report produce no user-space frames even though PERF_SAMPLE_REGS_USER/PERF_SAMPLE_STACK_USER were recorded correctly.

Upstream mainline fixes this via the e_machine rework (ed52302f51cc "perf env: Add perf_env__e_machine helper and use in perf_env__arch"), which is too invasive for stable backport; this is the minimal equivalent.

Verified on QEMU (rva23u64, XuanTie xt-c930v-cp) with coremark: after this fix, perf script expands full user-space callchains (1882 samples, avg 6.9 frames/sample, max 9) from perf record --call-graph dwarf data.

## Summary by Sourcery

Normalize perf architecture handling for RISC-V and fix minor issues in the ipi benchmark sample.

Bug Fixes:
- Map RISC-V uname architectures (e.g. riscv64) to perf's expected riscv name to restore user-space callchain decoding.
- Correct ipi benchmark memory allocation sizes by using the number of pairs/broadcasts instead of an unrelated variable.

Enhancements:
- Add SPDX license identifier and clean up logging output in the ipi benchmark sample for clearer reporting.