### PR TITLE
perf build: Only build riscv64/ arch dir for riscv targets

### DIFF
--- a/tools/perf/arch/Build
+++ b/tools/perf/arch/Build
@@ -1,3 +1,8 @@
 perf-y += common.o
 perf-y += $(SRCARCH)/
+# riscv64/ carries XuanTie additions (rdtime asm in util/tsc.c, ntrace);
+# only build it for riscv-family targets, otherwise x86 builds fail on rv asm.
+# When SRCARCH=riscv64 it is already covered by $(SRCARCH)/ above.
+ifeq ($(SRCARCH),riscv)
 perf-y += riscv64/
+endif


### PR DESCRIPTION
## Summary

`tools/perf/arch/Build` unconditionally adds `riscv64/` (XuanTie additions: `rdtime` inline asm in `util/tsc.c`, xuantie-ntrace) to `perf-y`. On x86 hosts this pulls RISC-V assembly into the build and breaks the native perf build:

```
arch/riscv64/util/tsc.c: Assembler messages:
Error: unrecognized opcode `rdtime ...'
```

## Fix

Gate `riscv64/` on `SRCARCH=riscv`. For `SRCARCH=riscv64` the directory is already covered by the `$(SRCARCH)/` entry, so riscv64 builds are unaffected.

## Test plan

- [x] x86 native build: `make -C tools/perf` links successfully (failed before the fix)
- [x] riscv64 cross build: `tsc.o` / `xuantie-ntrace.o` compile as before, no regression

## Summary by Sourcery

Bug Fixes:
- Prevent x86 perf builds from failing due to unconditional inclusion of riscv64 sources containing RISC-V-specific assembly instructions.