### PR TITLE
riscv: clean up build warnings and restore compressed image selection

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -180,17 +180,6 @@ vdso-install-$(CONFIG_VDSO64)		+= arch/riscv/kernel/vdso/vdso64.so.dbg
 vdso-install-$(CONFIG_VDSO64ILP32)	+= arch/riscv/kernel/vdso/vdso64ilp32.so.dbg
 vdso-install-$(CONFIG_COMPAT)	+= arch/riscv/kernel/compat_vdso/compat_vdso.so.dbg:../compat_vdso/compat_vdso.so
 
-ifneq ($(CONFIG_XIP_KERNEL),y)
-ifeq ($(CONFIG_RISCV_M_MODE)$(CONFIG_ARCH_CANAAN),yy)
-KBUILD_IMAGE := $(boot)/loader.bin
-else
-ifeq ($(CONFIG_EFI_ZBOOT),)
-KBUILD_IMAGE := $(boot)/Image
-else
-KBUILD_IMAGE := $(boot)/vmlinuz.efi
-endif
-endif
-endif
 BOOT_TARGETS := Image Image.gz Image.bz2 Image.lz4 Image.lzma Image.lzo Image.zst loader loader.bin xipImage vmlinuz.efi
 
 all:	$(notdir $(KBUILD_IMAGE))

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -162,15 +162,6 @@ KBUILD_IMAGE				:= $(boot)/$(boot-image-y)
 libs-y += arch/riscv/lib/
 libs-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
 
-PHONY += vdso_install
-vdso_install:
-	$(if $(CONFIG_VDSO32),$(Q)$(MAKE) \
-		$(build)=arch/riscv/kernel/vdso vdso32_install
-	$(if $(CONFIG_VDSO64),$(Q)$(MAKE) \
-		$(build)=arch/riscv/kernel/vdso vdso64_install
-	$(if $(CONFIG_VDSO64ILP32),$(Q)$(MAKE) \
-		$(build)=arch/riscv/kernel/vdso vdso64ilp32_install
-
 ifeq ($(KBUILD_EXTMOD),)
 ifeq ($(CONFIG_MMU),y)
 prepare: vdso_prepare
@@ -184,7 +175,9 @@ vdso_prepare: prepare0
 endif
 endif
 
-vdso-install-y			+= arch/riscv/kernel/vdso/vdso.so.dbg
+vdso-install-$(CONFIG_VDSO32)		+= arch/riscv/kernel/vdso/vdso32.so.dbg
+vdso-install-$(CONFIG_VDSO64)		+= arch/riscv/kernel/vdso/vdso64.so.dbg
+vdso-install-$(CONFIG_VDSO64ILP32)	+= arch/riscv/kernel/vdso/vdso64ilp32.so.dbg
 vdso-install-$(CONFIG_COMPAT)	+= arch/riscv/kernel/compat_vdso/compat_vdso.so.dbg:../compat_vdso/compat_vdso.so
 
 ifneq ($(CONFIG_XIP_KERNEL),y)

--- a/include/linux/firmware/xuantie/th1520_event.h
+++ b/include/linux/firmware/xuantie/th1520_event.h
@@ -20,11 +20,11 @@ enum th1520_rebootmode_index {
 extern int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode);
 extern int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode);
 #else
-static int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode)
+static inline int th1520_event_set_rebootmode(enum th1520_rebootmode_index mode)
 {
 	return 0;
 }
-static int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode)
+static inline int th1520_event_get_rebootmode(enum th1520_rebootmode_index *mode)
 {
 	*mode = TH1520_EVENT_MAX;
 


### PR DESCRIPTION
This series fixes two build warnings reported by CI and one packaging failure. First, the top-level Makefile already provides a generic vdso_install target, but arch/riscv still carries the old arch-specific rule, triggering "overriding recipe" warnings; the stale vdso-install-y entry (vdso.so.dbg, which does not exist in this tree) is also corrected to list the real build products (vdso32/64/64ilp32, config-gated), keeping install behaviour identical to the old rule. Second, the TH1520 rebootmode fallback stubs are made static inline to silence -Wunused-function warnings. Third, and most importantly, a redundant KBUILD_IMAGE override block forced the default image back to plain Image, so Image.gz was never built even with CONFIG_KERNEL_GZIP=y and packaging failed with "cannot create gzip compressed kernel"; dropping the block restores the boot-image-y based selection, so the default image follows the configured compression while the historical loader.bin (M-mode/Canaan), vmlinuz.efi (ZBOOT) and xipImage cases keep equivalent behaviour, matching mainline.

## Summary by Sourcery

Restore configuration-driven RISC-V boot image selection and clean up VDSO installation and TH1520 fallback warnings.

Bug Fixes:
- Restore compressed RISC-V kernel image selection so configured outputs such as Image.gz are built and packaged correctly.
- Correct RISC-V VDSO installation artifacts and remove the conflicting architecture-specific installation rule.
- Silence unused-function build warnings for TH1520 rebootmode fallback stubs.