### PR TITLE
riscv: dts: fix node unit-address/names to silence dtc warnings

### DIFF
--- a/arch/riscv/boot/dts/canaan/k230-evb.dts
+++ b/arch/riscv/boot/dts/canaan/k230-evb.dts
@@ -58,7 +58,7 @@
 
 &i2c4 {
 	status = "okay";
-	gt911: touchscreen@5d {
+	gt911: touchscreen@14 {
 		compatible = "goodix,gt911";
 		reg = <0x14>;
 

--- a/arch/riscv/boot/dts/canaan/k230.dtsi
+++ b/arch/riscv/boot/dts/canaan/k230.dtsi
@@ -765,7 +765,7 @@
 			vo_out: port {
 				#address-cells = <1>;
 				#size-cells = <0>;
-				vop_out_dsi: endpoint@1 {
+				vop_out_dsi: endpoint@0 {
 					reg = <0>;
 					remote-endpoint = <&dsi_in_vop>;
 				};

--- a/arch/riscv/boot/dts/thead/th1520.dtsi
+++ b/arch/riscv/boot/dts/thead/th1520.dtsi
@@ -1481,7 +1481,7 @@
 			status = "disabled";
 		};
 
-		qspi0: qspi@ffea000000 {
+		qspi0: spi@ffea000000 {
 			compatible = "snps,dw-apb-ssi-quad";
 			reg = <0xff 0xea000000 0x0 0x1000>;
 			interrupts = <52 IRQ_TYPE_LEVEL_HIGH>;
@@ -1493,7 +1493,7 @@
 			status = "disabled";
 		};
 
-		qspi1: qspi@fff8000000 {
+		qspi1: spi@fff8000000 {
 			compatible = "snps,dw-apb-ssi-quad";
 			reg = <0xff 0xf8000000 0x0 0x1000>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
Fix dtc warnings:
```
  k230.dtsi: Warning (graph_endpoint): /soc/vo@90840000/port/endpoint@1:
    graph node unit address error, expected "0"
  k230-evb.dts: Warning (i2c_bus_reg): /soc/i2c@91409000/touchscreen@5d:
    I2C bus unit address format error, expected "14"
  th1520.dtsi: Warning (spi_bus_bridge): /soc/qspi@fff8000000:
    node name for SPI buses should be 'spi'
  th1520-lichee-pi-4a.dtb: Warning (spi_bus_reg):
    Failed prerequisite 'spi_bus_bridge'
```
Rename the vo endpoint to endpoint@0 to match its reg = <0>, the gt911 touchscreen to touchscreen@14 to match its reg = <0x14> (the I2C address used on this board), and the th1520 QSPI controller nodes to the standard 'spi' name. Only node names change; labels and phandle references are untouched.

## Summary by Sourcery

Bug Fixes:
- Correct RISC-V device-tree node names and unit addresses to eliminate dtc validation warnings for graph endpoints, I2C devices, and SPI controllers.