### PR TITLE
riscv: cmpxchg: Use .option arch for Zacas and Zabha

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -69,12 +69,6 @@ else
 riscv-march-$(CONFIG_TOOLCHAIN_NEEDS_EXPLICIT_ZICSR_ZIFENCEI) := $(riscv-march-y)_zicsr_zifencei
 endif
 
-# Check if the toolchain supports Zacas
-riscv-march-$(CONFIG_TOOLCHAIN_HAS_ZACAS) := $(riscv-march-y)_zacas
-
-# Check if the toolchain supports Zabha
-riscv-march-$(CONFIG_TOOLCHAIN_HAS_ZABHA) := $(riscv-march-y)_zabha
-
 # XUANTIE ISA
 riscv-march-$(CONFIG_XUANTIE_ISA) := $(riscv-march-y)_xtheadc
 

--- a/arch/riscv/include/asm/cmpxchg.h
+++ b/arch/riscv/include/asm/cmpxchg.h
@@ -26,7 +26,10 @@
 									\
 		__asm__ __volatile__ (					\
 			prepend						\
+			"	.option push\n"					\
+			"	.option arch, +zabha\n"			\
 			"	amoswap" swap_sfx " %0, %z2, %1\n"	\
+			"	.option pop\n"					\
 			swap_append					\
 			: "=&r" (r), "+A" (*(p))			\
 			: "rJ" (n)					\
@@ -151,7 +154,10 @@ end:;									\
 									\
 		__asm__ __volatile__ (					\
 			cas_prepend					\
+			"	.option push\n"					\
+			"	.option arch, +zacas, +zabha\n"			\
 			"	amocas" cas_sfx " %0, %z2, %1\n"	\
+			"	.option pop\n"					\
 			cas_append					\
 			: "+&r" (r), "+A" (*(p))			\
 			: "rJ" (n)					\
@@ -205,7 +211,10 @@ end:;									\
 									\
 		__asm__ __volatile__ (					\
 			cas_prepend					\
+			"	.option push\n"					\
+			"	.option arch, +zacas\n"			\
 			"	amocas" cas_sfx " %0, %z2, %1\n"	\
+			"	.option pop\n"					\
 			cas_append					\
 			: "+&r" (r), "+A" (*(p))			\
 			: "rJ" (n)					\
@@ -453,7 +462,10 @@ union __u128_halves {
 	register unsigned long x29 asm ("x29") = __ho.high;			\
 										\
 	__asm__ __volatile__ (							\
-		"	amocas.q" cas_sfx " %0, %z3, %2"			\
+			"	.option push\n"					\
+			"	.option arch, +zacas\n"			\
+		"	amocas.q" cas_sfx " %0, %z3, %2\n"			\
+			"	.option pop\n"					\
 		: "+&r" (x28), "+&r" (x29), "+A" (*(p))				\
 		: "rJ" (x6), "rJ" (x7)						\
 		: "memory");							\


### PR DESCRIPTION
Instead of adding these to -march globally, use .option arch to use instructions from these extensions only in code paths where we know they are available, like how it is done for most other extensions. TOOLCHAIN_HAS_{ZACAS,ZABHA} already depend on AS_HAS_OPTION_ARCH, so this is not a functionality regression even on older assemblers.

Although the compiler is unlikely to generate atomics on its own accord, this aligns handling of Zacas and Zabha with most other extensions and improves consistency on how assembly code requiring extra extensions is written in kernel code.

This is analogous to the use of __LSE_PREAMBLE or .arch_extension lse in arm64 code.


Reviewed-by: Jesse Taube <jtaubepe@redhat.com>
Link: https://patch.msgid.link/20260717-riscv-no-zacas-zabha-in-march-v1-1-82b5b0799fb6@iscas.ac.cn

## Summary by Sourcery

Scope Zacas and Zabha support to the RISC-V atomic instruction paths that require them.

Enhancements:
- Use scoped assembler architecture options for RISC-V Zacas and Zabha atomic instructions instead of enabling both extensions globally in the kernel build.

Build:
- Stop adding Zacas and Zabha to the global RISC-V architecture target.