### PR TITLE
RISC-V: KVM: Redirect AMO load/store access fault traps to guest

### DIFF
--- a/arch/riscv/kvm/vcpu_exit.c
+++ b/arch/riscv/kvm/vcpu_exit.c
@@ -185,6 +185,8 @@ int kvm_riscv_vcpu_exit(struct kvm_vcpu *vcpu, struct kvm_run *run,
 	case EXC_INST_ILLEGAL:
 	case EXC_LOAD_MISALIGNED:
 	case EXC_STORE_MISALIGNED:
+	case EXC_LOAD_ACCESS:
+	case EXC_STORE_ACCESS:
 		if (vcpu->arch.guest_context.hstatus & HSTATUS_SPV) {
 			kvm_riscv_vcpu_trap_redirect(vcpu, trap);
 			ret = 1;


### PR DESCRIPTION
Backport upstream commit e325618349cdc1fbbe63574080249730e7cff9ea (merged in mainline v6.10-rc1) to `linux-6.6.36`.

## Problem

The KVM RISC-V does not delegate AMO load/store access fault traps to VS-mode (`hedeleg`), so M-mode takes these traps and redirects them back to HS-mode. Upon returning from M-mode, the KVM RISC-V running in HS-mode terminates the VS-mode software instead of letting the guest handle the fault.

## Fix

Redirect `EXC_LOAD_ACCESS` / `EXC_STORE_ACCESS` traps back to VS-mode (2-line change in `arch/riscv/kvm/vcpu_exit.c`), letting the guest trap handler decide the next steps — same as upstream.

## Notes

- Clean cherry-pick: the 6.6.36 base matches the upstream pre-image exactly, applied without conflicts.
- Not backported to the 6.6 stable series, hence the manual backport.
- Original commit: Yu-Wei Hsu, Reviewed-by Anup Patel; full sign-off chain preserved.

## Summary by Sourcery

Bug Fixes:
- Redirect RISC-V AMO load and store access-fault traps to VS-mode so guest handlers can process them instead of terminating guest software.