### PR TITLE
perf: xuantie_link_pmu: Map registers without reserving the shared page

### DIFF
--- a/drivers/perf/xuantie_link_pmu.c
+++ b/drivers/perf/xuantie_link_pmu.c
@@ -834,10 +834,13 @@ static int xuantie_link_pmu_device_probe(struct platform_device *pdev)
 		return -ENOMEM;
 	}
 
-	xuantie_link_pmu->pmu_base =
-		devm_platform_get_and_ioremap_resource(pdev, 0, &res);
-	if (IS_ERR(xuantie_link_pmu->pmu_base))
-		return PTR_ERR(xuantie_link_pmu->pmu_base);
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!res)
+		return -EINVAL;
+	xuantie_link_pmu->pmu_base = devm_ioremap(&pdev->dev, res->start,
+						  resource_size(res));
+	if (!xuantie_link_pmu->pmu_base)
+		return -ENOMEM;
 
 	xuantie_link_pmu->devtype_data = of_device_get_match_data(&pdev->dev);
 	if (!xuantie_link_pmu->devtype_data) {


### PR DESCRIPTION
The XL300 PMU and the CBQRI capacity controller have conflicting register spaces in the same 4KB page, so the PMU probe fails with -EBUSY when CBQRI requests its region first. Map the PMU registers without requesting the page so both drivers can probe.

## Summary by Sourcery

Enable shared-page register mapping for the XuanTie Link PMU so it can coexist with the CBQRI capacity controller.

Bug Fixes:
- Allow the XL300 PMU and CBQRI drivers to probe successfully when they share a memory-mapped register page.

Enhancements:
- Map PMU registers without reserving the overlapping memory resource, preventing probe failures caused by resource ownership conflicts.