### PR TITLE
riscv_cbqri: resctrl: Initialize default_ctrl to the full capacity mask

### DIFF
--- a/drivers/resctrl/cbqri_resctrl.c
+++ b/drivers/resctrl/cbqri_resctrl.c
@@ -462,6 +462,7 @@ static void cbqri_resctrl_control_init(struct cbqri_resctrl_res *cbqri_res)
 		res->ctrl_scope = (res->rid == RDT_RESOURCE_L2) ?
 				    RESCTRL_L2_CACHE : RESCTRL_L3_CACHE;
 		res->cache.cbm_len = ctrl->cc.ncblks;
+		res->default_ctrl = GENMASK(ctrl->cc.ncblks - 1, 0);
 		res->cache.shareable_bits = 0;
 		res->cache.min_cbm_bits = 1;
 		res->cache.arch_has_sparse_bitmasks = false;


### PR DESCRIPTION
cbqri_resctrl_control_init() fills the resource capabilities such as cache.cbm_len but never assigns rdt_resource::default_ctrl. The field therefore stays at its static zero value, so the resctrl filesystem exposes an all-zero CBM: /sys/fs/resctrl/info/L3/cbm_mask reads 0, and cbqri_init_domain_ctrlval() programs CONFIG_LIMIT with a zero block mask for every RCID, making the schemata and size files read back L3:0=0 as well.

Initialize default_ctrl to BIT_MASK(ncblks) - 1, i.e. the mask that covers every capacity block reported in cc_capabilities.NCBLKS, the same semantics as the x86 resctrl default control value.

## Summary by Sourcery

Bug Fixes:
- Initialize the resctrl default control mask to cover all reported cache capacity blocks, restoring full-capacity CBMs and correct default schemata values.